### PR TITLE
Fixed issue#8: Implement Feature for User-Controlled Data Display Limit

### DIFF
--- a/templatetags/dynamic_agenda_tags.py
+++ b/templatetags/dynamic_agenda_tags.py
@@ -5,17 +5,27 @@ from django_dynamic_agenda.models import AgendaItem, AgendaGroup
 register = template.Library()
 
 @register.inclusion_tag('django_dynamic_agenda/agenda_items.html')
-def show_agenda(group_name=None):
+def show_agenda(group_name=None, items_limit=None):
+
+    try:
+        if items_limit:
+            items_limit = int(items_limit)
+    except ValueError:
+        items_limit = None
+
     if group_name:
-        items = AgendaItem.objects.filter(group__name=group_name)
+        items = AgendaItem.objects.filter(group__name=group_name).order_by('-created')
     else:
         latest_group = AgendaGroup.objects.annotate(
             latest_date=Max('items__created')
         ).order_by('-latest_date').first()
 
         if latest_group:
-            items = latest_group.items.all()
+            items = latest_group.items.all().order_by('-created')
         else:
             items = AgendaItem.objects.none()
+
+    if items_limit:
+        items = items[:items_limit]
 
     return {'items': items}

--- a/templatetags/dynamic_agenda_tags.py
+++ b/templatetags/dynamic_agenda_tags.py
@@ -7,6 +7,7 @@ register = template.Library()
 @register.inclusion_tag('django_dynamic_agenda/agenda_items.html')
 def show_agenda(group_name=None, items_limit=None):
 
+    # Convert limit to integer and it not convertible to int then default to none
     try:
         if items_limit:
             items_limit = int(items_limit)
@@ -25,6 +26,7 @@ def show_agenda(group_name=None, items_limit=None):
         else:
             items = AgendaItem.objects.none()
 
+    # Apply limit to the queryset if a limit parameter is specified and is an integer
     if items_limit:
         items = items[:items_limit]
 


### PR DESCRIPTION
Added the items limit functionality to control the number of agenda items returned by the show_agenda method:

Enhanced the show_agenda function to accept a 'limit' parameter that controls the maximum number of AgendaItem objects returned. This update ensures the function can return a specified number of the most recent items from either a specified group or the latest group by default. It handles non-integer and absent limits gracefully by defaulting to returning all items.

- Added limit parameter handling with proper integer type checking.
- Implemented conditional query set slicing based on the limit.