### PR TITLE
Changed datatype of 'time' field from CharField to DateField

### DIFF
--- a/models.py
+++ b/models.py
@@ -8,7 +8,7 @@ class AgendaGroup(models.Model):
 
 class AgendaItem(models.Model):
     group = models.ForeignKey(AgendaGroup, on_delete=models.CASCADE, related_name='items')
-    time = models.CharField(max_length=100)
+    time = models.DateField()
     created = models.DateTimeField(auto_now_add=True)
     description = models.TextField()
 


### PR DESCRIPTION
Fixes issue #10 

Changes the data type of the `time` field in the `AgendaItem` class from `CharField` to `DateField`