### PR TITLE
updated meaningful name to the TimeTable class attribute

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -13,5 +13,5 @@ class EventAdmin(admin.ModelAdmin):
 
 @admin.register(TimeTable)
 class TimeTableAdmin(admin.ModelAdmin):
-    list_display = ('group', 'start_time', 'created', 'description')
-    list_filter = ('group', 'start_time', 'created')
+    list_display = ('item_event', 'start_time', 'created', 'description')
+    list_filter = ('item_event', 'start_time', 'created')

--- a/models.py
+++ b/models.py
@@ -23,7 +23,7 @@ class Event(models.Model):
     def __str__(self):
         return self.name
 class TimeTable(models.Model):
-    group = models.ForeignKey(Event, on_delete=models.CASCADE, related_name='items')
+    item_event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name='items', verbose_name="Event Name")
     start_time = models.TimeField(verbose_name="Time", help_text="When this will start")
     created = models.DateTimeField(auto_now_add=True)
     description = models.TextField(verbose_name="Event Description", help_text="Event activity/description what will happen at this time")

--- a/templates/django_dynamic_agenda/agenda_items.html
+++ b/templates/django_dynamic_agenda/agenda_items.html
@@ -1,13 +1,13 @@
 {% load static %}
 <div class="dj_timetable_container">
     {% if items %}
-    <div class="dj_timetable_calendar {{ items.first.group.theme_color }}">
+    <div class="dj_timetable_calendar {{ items.first.item_event.theme_color }}">
         <div class="dj_timetable_calendar_header">
-            <h1 class="dj_timetable_header_title">{{ items.first.group.name }}</h1>
+            <h1 class="dj_timetable_header_title">{{ items.first.item_event.name }}</h1>
         </div>
         <div class="dj_timetable_calendar_events">
             <p class="dj_timetable_ce_title">Upcoming Event on 
-                <span class="dj_timetable_agenda_badge">{{ items.first.group.start_date }}</span> 
+                <span class="dj_timetable_agenda_badge">{{ items.first.item_event.start_date }}</span> 
                 in <span class="dj_timetable_agenda_badge">{{ days_until_event }}</span> days
             </p>
             {% for item in items %}


### PR DESCRIPTION
Fixes issue #18 

Changed the field name in the `TimeTable` model from `group` to `item_event` and set its `verbose_name` attribute. Also made the relevant changes in the admin.py and HTML files.